### PR TITLE
Add release workflow using trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          pip install twine
           uv sync --all-packages
       - name: Test with pytest for release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       python_release_version:
         description: "Python version to use for build and publish"
-        required: true
+        required: false
         default: "3.12"
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python for Release
         uses: actions/setup-python@v4
         with:
-          python-version: "${{ inputs.python_release_version }}"
+          python-version: "${{ github.event.inputs.python_release_version || '3.12' }}"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: # Allow manual triggering of the workflow
     inputs:
       python_release_version:
-        description: "Python version to publish"
+        description: "Python version to use for build and publish"
         required: true
         default: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch: # Allow manual triggering of the workflow
+    inputs:
+      python_release_version:
+        description: "Python version to publish"
+        required: true
+        default: "3.12"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/deltastream-connector
+    permissions:
+      id-token: write # for trusted publishing without token/secret
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python for Release
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ inputs.python_release_version }}"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          pip install twine
+          uv sync --all-packages
+      - name: Test with pytest for release
+        run: |
+          uv run pytest
+      - name: Test build
+        run: |
+          uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: production
       url: https://pypi.org/p/deltastream-connector
     permissions:
       id-token: write # for trusted publishing without token/secret


### PR DESCRIPTION
PyPi project has been setup for trusted publishing for this repository.
PyPi publishing doc: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#trusted-publishing